### PR TITLE
Option to auto submit form after alert

### DIFF
--- a/src/js/content/frame/index.js
+++ b/src/js/content/frame/index.js
@@ -50,12 +50,44 @@ const Popup = () => {
     }
     let theme = 'light';
     let colorSet = 'normal';
+    let autoAllow = false;
+    let autoAllowTimeout = 0;
+
     if (storage.preferences && storage.preferences.darkMode) {
       theme = 'dark';
     }
     if (storage.preferences.colorset) {
       colorSet = storage.preferences.colorset;
     }
+    if (storage.preferences.autoAllow) {
+      autoAllow = true;
+      autoAllowTimeout = storage.preferences.autoAllowTimeout || 10;
+    }
+
+    let continueButton;
+
+    if (autoAllow) {
+      const seconds = autoAllowTimeout;
+      setTimeout(() => onContinue, seconds * 1000);
+      continueButton = (
+        <button
+          role="button"
+          className={styles.continueBtn}
+          onClick={onContinue}
+        >
+          <span
+            className={styles.progressBar}
+            style={{
+              animationDuration: `${seconds}s`
+            }}
+          />
+          <span className={styles.progressText}>Continue anyway →</span>
+        </button>
+      );
+    } else {
+      continueButton = <Button onClick={onContinue}>Continue anyway →</Button>;
+    }
+
     return (
       <div className={styles.container} data-color-theme={theme}>
         <div className={styles.popup}>
@@ -67,7 +99,7 @@ const Popup = () => {
             <Button muted onClick={onCancel}>
               Cancel
             </Button>
-            <Button onClick={onContinue}>Continue anyway →</Button>
+            {continueButton}
           </div>
 
           <ul className={styles.popupOptions}>

--- a/src/js/content/frame/index.js
+++ b/src/js/content/frame/index.js
@@ -68,7 +68,7 @@ const Popup = () => {
 
     if (autoAllow) {
       const seconds = autoAllowTimeout;
-      setTimeout(() => onContinue, seconds * 1000);
+      setTimeout(onContinue, seconds * 1000);
       continueButton = (
         <button
           role="button"

--- a/src/js/content/frame/popup.module.scss
+++ b/src/js/content/frame/popup.module.scss
@@ -1,5 +1,6 @@
 @import '../../../styles/mixins/themes.scss';
 @import '../../../styles/common/colors.scss';
+@import '../../components/button/button.module.scss';
 
 .container {
   padding: 20px 20px 4px 2px;
@@ -63,5 +64,40 @@
 
   li:first-child a {
     margin-left: 0;
+  }
+}
+
+.continue-btn {
+  @extend .btn;
+  overflow: hidden;
+}
+
+.progress-bar {
+  display: block;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  z-index: 1;
+  animation-name: progressAnimation;
+  animation-iteration-count: 1;
+  animation-fill-mode: forwards;
+  animation-timing-function: linear;
+
+  @include themify() {
+    background-color: darken(theme('buttonBackground'), 20%);
+  }
+}
+
+.progress-text {
+  z-index: 2;
+}
+
+@keyframes progressAnimation {
+  from {
+    width: 0%;
+  }
+  to {
+    width: 100%;
   }
 }

--- a/src/js/options/pages/preferences/index.js
+++ b/src/js/options/pages/preferences/index.js
@@ -29,10 +29,12 @@ function Prefs() {
 
   const {
     alertOnSubmit,
-    blockedRank = 'C',
+    blockedRank = 'A',
     ignoredEmailAddresses = [],
     ignoredSites = [],
-    colorSet = 'normal'
+    colorSet = 'normal',
+    autoAllow = true,
+    autoAllowTimeout = 10
   } = user.preferences;
 
   const onChange = useCallback(
@@ -72,7 +74,9 @@ function Prefs() {
         blockedRank={blockedRank}
         ignoredEmailAddresses={ignoredEmailAddresses}
         ignoredSites={ignoredSites}
-        colorblind={colorSet === 'colorblind'}
+        colorSet={colorSet}
+        autoAllow={autoAllow}
+        autoAllowTimeout={autoAllowTimeout}
         setPreference={setPreference}
         changeEmailIgnoreList={changeEmailIgnoreList}
         changeSiteIgnoreList={changeSiteIgnoreList}
@@ -86,7 +90,9 @@ function AlertContent({
   blockedRank,
   ignoredEmailAddresses,
   ignoredSites,
-  colorblind,
+  colorSet,
+  autoAllow,
+  autoAllowTimeout,
   setPreference,
   changeEmailIgnoreList,
   changeSiteIgnoreList
@@ -94,6 +100,7 @@ function AlertContent({
   if (!show) {
     return null;
   }
+
   return (
     <>
       <div className={styles.pageSection}>
@@ -115,7 +122,7 @@ function AlertContent({
                 }
               }}
             >
-              <Rank rank={rank} colorblind={colorblind} />
+              <Rank rank={rank} colorblind={colorSet === 'colorblind'} />
             </Radio>
           ))}
         </div>
@@ -129,6 +136,35 @@ function AlertContent({
             .
           </p>
         </div>
+      </div>
+      <div className={styles.pageSection}>
+        <h2>Form submission</h2>
+        <p>We will automatically submit the form after the popup is shown.</p>
+        <div className={styles.formGroup}>
+          <FormCheckbox
+            name="autoAllow"
+            checked={autoAllow}
+            onChange={() => setPreference({ autoAllow: !autoAllow })}
+            label={`Automatically allow after ${autoAllowTimeout} seconds`}
+          />
+        </div>
+        {!autoAllow ? null : (
+          <div className={styles.formGroup}>
+            <FormInput
+              name={name}
+              label="Seconds until auto submission"
+              type="number"
+              min="1"
+              max="60"
+              step="1"
+              value={autoAllowTimeout}
+              onChange={({ currentTarget }) => {
+                setPreference({ autoAllowTimeout: +currentTarget.value });
+              }}
+            />
+            <span className={styles.help}>Between 1 and 60 seconds</span>
+          </div>
+        )}
       </div>
       <div className={styles.pageSection}>
         <h2>Ignore emails</h2>

--- a/src/js/options/pages/preferences/preferences.module.scss
+++ b/src/js/options/pages/preferences/preferences.module.scss
@@ -1,5 +1,7 @@
 @import '../../../../styles/common/colors.scss';
+@import '../../../../styles/mixins/themes.scss';
 @import '../layout.module.scss';
+@import '../../../components/button/button.module.scss';
 
 .page-section {
   @extend .section;
@@ -52,5 +54,44 @@
   label {
     display: flex;
     flex-direction: column;
+  }
+}
+
+.form-group {
+  margin-bottom: 40px;
+}
+
+.test-btn {
+  @extend .btn;
+  overflow: hidden;
+}
+
+.progress-bar {
+  display: block;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  z-index: 1;
+  animation-name: progress;
+  animation-iteration-count: 1;
+  animation-fill-mode: forwards;
+  animation-timing-function: linear;
+
+  @include themify() {
+    background-color: darken(theme('buttonBackground'), 20%);
+  }
+}
+
+.progress-text {
+  z-index: 2;
+}
+
+@keyframes progress {
+  from {
+    width: 0%;
+  }
+  to {
+    width: 100%;
   }
 }

--- a/src/js/providers/user-provider.js
+++ b/src/js/providers/user-provider.js
@@ -249,8 +249,10 @@ query User($licenceKey: ID!) {
       ignoredEmailAddresses
       ignoredSites
       blockedRank
+      autoAllow
+      autoAllowTimeout
     }
-    features    
+    features
     referralCode
   }
 }

--- a/src/js/providers/user-reducer.js
+++ b/src/js/providers/user-reducer.js
@@ -5,10 +5,12 @@ export const initialState = {
     preferences: {
       darkMode: false,
       colorSet: 'normal',
-      alertOnSubmit: true,
+      alertOnSubmit: false,
       ignoredEmailAddresses: [],
       ignoredSites: [],
-      blockedRank: 'A'
+      blockedRank: 'A',
+      autoAllow: true,
+      autoAllowTimeout: 10
     }
   },
   licenceKey: '',

--- a/src/js/utils/preferences.js
+++ b/src/js/utils/preferences.js
@@ -10,6 +10,8 @@ mutation User($preferences: Preferences!) {
       ignoredEmailAddresses
       ignoredSites
       blockedRank
+      autoAllow
+      autoAllowTimeout
     }
   }
 }


### PR DESCRIPTION
# Add another preference setting to enable auto submitting forms

If the alert on submit setting is enabled then you can now enable the option to auto submit a form after a certain amount of time (default 10 seconds) after the popup is shown.

## Features

- New preferences checkbox to auto allow form submission after the alert shows
- Option to change the amount of time until the form is submitted
- Add progress bar to the popup continue button to show how much time until form submits

## Changes

- Change the option to alert on form submission to false by default