### PR TITLE
Fix alerts still showing for ignored sites

### DIFF
--- a/src/js/background/scores.js
+++ b/src/js/background/scores.js
@@ -1,14 +1,15 @@
+import { get, put } from '../utils/cache';
+import { getItem, pushPreference } from '../utils/storage';
+
 import { graphqlRequest } from '../utils/request';
 import isMailProvider from '../utils/is-mail-provider';
-import { get, put } from '../utils/cache';
-import { pushPreference, getItem } from '../utils/storage';
 import { updateUserPreferences } from '../utils/preferences';
 
 // just get the rank to show in the
 // subscription score icon
 const gql = `
 query Search($domain: String!) {
-  searchDomain(domain: $domain) {    
+  searchDomain(domain: $domain) {
     rank
     domain
   }
@@ -21,8 +22,11 @@ export async function getDomainScore(url) {
     return null;
   }
   const cachedResult = await get(domain);
-  if (cachedResult) {
-    return cachedResult;
+  if (cachedResult && cachedResult.normalizedDomain) {
+    return {
+      ...cachedResult,
+      domain: cachedResult.normalizedDomain
+    };
   }
   const options = {
     variables: {
@@ -31,13 +35,15 @@ export async function getDomainScore(url) {
   };
   const d = await graphqlRequest(gql, options);
   const rank = d.searchDomain ? d.searchDomain.rank : null;
-  put(domain, rank);
+  // this should always be returned by the gql search query but check in case
+  const normalizedDomain = d.searchDomain ? d.searchDomain.domain : domain;
+  put(domain, rank, normalizedDomain);
   return d.searchDomain;
 }
 
 const gqlBlocked = `
 mutation SignupRequest($domain: String!, $allowed: Boolean!) {
-  addSignupRequest(domain: $domain, allowed: $allowed) {    
+  addSignupRequest(domain: $domain, allowed: $allowed) {
     success
   }
 }

--- a/src/js/content/index.js
+++ b/src/js/content/index.js
@@ -1,3 +1,5 @@
+import browser from 'browser';
+import { getPreference } from '../utils/storage';
 // This is the content script injected into every page
 // specified in the `matches` param in the manifest
 //
@@ -9,8 +11,6 @@
 // list then we inject our popup that alerts the user
 //
 import { injectModal } from './modal';
-import { getPreference } from '../utils/storage';
-import browser from 'browser';
 
 const ranks = ['F', 'E', 'D', 'C', 'B', 'A', 'A+'];
 let haltedForm;
@@ -90,7 +90,11 @@ function onSubmitForm(
     const isIgnored = ignoredSites.some(is => is === domain);
     console.log('[subscriptionscore]: ranked', `${rank} - ${domain}`);
 
-    if (!isIgnored && ranks.indexOf(rank) <= ranks.indexOf(blockedRank)) {
+    const isBelowAlertThreshold =
+      !!rank && ranks.indexOf(rank) <= ranks.indexOf(blockedRank);
+    const blockFormSubmit = !isIgnored && isBelowAlertThreshold;
+
+    if (blockFormSubmit) {
       console.log('[subscriptionscore]: preventing form submit');
       injectModal({
         onApproved,

--- a/src/js/content/index.js
+++ b/src/js/content/index.js
@@ -91,7 +91,7 @@ function onSubmitForm(
     console.log('[subscriptionscore]: ranked', `${rank} - ${domain}`);
 
     const isBelowAlertThreshold =
-      !!rank && ranks.indexOf(rank) <= ranks.indexOf(blockedRank);
+      ranks.indexOf(rank) <= ranks.indexOf(blockedRank);
     const blockFormSubmit = !isIgnored && isBelowAlertThreshold;
 
     if (blockFormSubmit) {

--- a/src/js/utils/cache.js
+++ b/src/js/utils/cache.js
@@ -39,14 +39,14 @@ if (indexedDB) {
   };
 }
 
-export function put(domain, rank) {
+export function put(domain, rank, normalizedDomain) {
   if (!db) return null;
   const tx = db.transaction([DB_NAME], 'readwrite');
   const objectStore = tx.objectStore(DB_NAME);
   return new Promise((resolve, reject) => {
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject();
-    objectStore.put({ domain, rank, timestamp: Date.now() });
+    objectStore.put({ domain, rank, normalizedDomain, timestamp: Date.now() });
   });
 }
 


### PR DESCRIPTION
# Fix alerts still showing for ignored sites

Ignored sites are added using normalized domains; e.g. dashboard.stripe.com is normalized to stripe.com, but the popup was using the un-normalized domain.

## Changes

- use the normalized domain to check in the ignored sites
- don't show the popup if the site is ignored
- add normalized domain to the cached value
