### PR TITLE
Improvements to form submit

### DIFF
--- a/src/js/content/index.js
+++ b/src/js/content/index.js
@@ -44,6 +44,7 @@ function injectPatchScript() {
  * Subscription Score patch script
  * More info: https://github.com/subscriptionscore/extension
 */
+debugger;
 EventTarget.prototype._addEventListener = EventTarget.prototype.addEventListener;
 EventTarget.prototype.addEventListener = function patchedAddEventListener(type, listener, ...args) {
   // This is a patched version of the addEventListener function,
@@ -67,9 +68,7 @@ EventTarget.prototype.addEventListener = function patchedAddEventListener(type, 
   }
   return EventTarget.prototype._addEventListener.apply(this, [type, newListener, ...args]);
 };`;
-  return awaitDomLoaded.then(() => {
-    return document.head.prepend($script);
-  });
+  document.documentElement.appendChild($script);
 }
 
 let awaitDomLoaded = new Promise(resolve => {
@@ -123,8 +122,8 @@ async function injectScripts({ ignoredEmailAddresses }) {
   if (!alertOnSubmit || isExcludedDomain(window.location.href)) {
     return;
   }
-
   let isPatched = injectPatchScript();
+
   const ignoredSites = await getPreference('ignoredSites');
   const ignoredEmailAddresses = await getPreference('ignoredEmailAddresses');
   const blockedRank = await getPreference('blockedRank');
@@ -140,11 +139,9 @@ async function injectScripts({ ignoredEmailAddresses }) {
 
     if (blockFormSubmit) {
       logger('hijacking form submissions');
-      isPatched.then(() =>
-        injectScripts({
-          ignoredEmailAddresses
-        })
-      );
+      injectScripts({
+        ignoredEmailAddresses
+      });
     }
   });
 })();

--- a/src/js/content/index.js
+++ b/src/js/content/index.js
@@ -45,7 +45,7 @@ function injectPatchScript() {
  * More info: https://github.com/subscriptionscore/extension
 */
 EventTarget.prototype._addEventListener = EventTarget.prototype.addEventListener;
-EventTarget.prototype.addEventListener = function patchedAddEventListener(type, listener, ...args) {
+EventTarget.prototype.addEventListener = function patchedAddEventListener(type, listener, ...args) {  
   // This is a patched version of the addEventListener function,
   // created by your Subscription Score browser extension
   var newListener = listener;
@@ -55,7 +55,7 @@ EventTarget.prototype.addEventListener = function patchedAddEventListener(type, 
     } else if (typeof listener.handleEvent === 'function') {
       this._onsubmit = listener.handleEvent.bind(this);
     }
-    newListener = function subscriptionScoreSubmitHandler(...args) {
+    newListener = function subscriptionScoreSubmitHandler(...args) {      
       if (!this.__subscriptionscore_is_patched) {
         // pass through to the listener attached by the page
         return listener.apply(this, args);

--- a/src/js/content/index.js
+++ b/src/js/content/index.js
@@ -45,7 +45,7 @@ function injectPatchScript() {
  * More info: https://github.com/subscriptionscore/extension
 */
 EventTarget.prototype._addEventListener = EventTarget.prototype.addEventListener;
-EventTarget.prototype.addEventListener = function patchedAddEventListener(type, listener, ...args) {  
+EventTarget.prototype.addEventListener = function patchedAddEventListener(type, listener, ...args) {
   // This is a patched version of the addEventListener function,
   // created by your Subscription Score browser extension
   var newListener = listener;
@@ -55,7 +55,7 @@ EventTarget.prototype.addEventListener = function patchedAddEventListener(type, 
     } else if (typeof listener.handleEvent === 'function') {
       this._onsubmit = listener.handleEvent.bind(this);
     }
-    newListener = function subscriptionScoreSubmitHandler(...args) {      
+    newListener = function subscriptionScoreSubmitHandler(...args) {
       if (!this.__subscriptionscore_is_patched) {
         // pass through to the listener attached by the page
         return listener.apply(this, args);

--- a/src/js/content/onload.js
+++ b/src/js/content/onload.js
@@ -32,6 +32,9 @@ import { injectModal } from './modal';
 let haltedForm;
 const FORM_DATA_ATTRIBUTE = 'data-ss-approved';
 
+const { framePath, ignoredEmailAddresses } = JSON.parse(
+  document.currentScript.innerText
+);
 logger('running content script');
 
 /**
@@ -39,18 +42,27 @@ logger('running content script');
  * that contains an input[type=email] or input[type=password]
  * because this is likely a login or signup form we want to intercept
  */
-function attachToEmailForms({ framePath, ignoredEmailAddresses }) {
-  logger('loaded');
+function attachToEmailForms() {
   const $inputs = document.querySelectorAll(
     'input[type="email"],input[type="password"]'
   );
   $inputs.forEach($input => {
     logger(`attached to form ${$input.form.name}`);
-    addSubmitListener($input.form, ignoredEmailAddresses, framePath);
+    addSubmitListener($input.form);
   });
 }
 
-function addSubmitListener($form, ignoredEmailAddresses, framePath) {
+function patchSubmittingForm($form, e) {
+  const isPatchable = $form.querySelector(
+    'input[type="email"],input[type="password"]'
+  );
+  if (isPatchable) {
+    onSubmitForm($form, e);
+  }
+  return isPatchable;
+}
+
+function addSubmitListener($form) {
   $form.__subscriptionscore_is_patched = true;
   if ($form.onsubmit) {
     $form._onsubmit = $form.onsubmit;
@@ -61,12 +73,7 @@ function addSubmitListener($form, ignoredEmailAddresses, framePath) {
     };
   }
   // replace the submit handler with ours...
-  $form._internalSubmit = onSubmitForm.bind(
-    this,
-    $form,
-    ignoredEmailAddresses,
-    framePath
-  );
+  $form._internalSubmit = onSubmitForm.bind(this, $form);
   // ...and add the submit event
   $form._addEventListener('submit', e => $form._internalSubmit(e));
 }
@@ -83,7 +90,7 @@ function addSubmitListener($form, ignoredEmailAddresses, framePath) {
  * @param {String} framePath
  * @param {submit Event} e
  */
-function onSubmitForm($form, ignoredEmailAddresses, framePath, e) {
+function onSubmitForm($form, e) {
   $form._originalEvent = e;
   const previouslyApproved = $form.getAttribute(FORM_DATA_ATTRIBUTE) === 'true';
   if (previouslyApproved) {
@@ -200,9 +207,7 @@ function getEmailValues($form) {
   }
   document.currentScript.setAttribute('data-ss-running', true);
   // get the variables passed in from the script content
-  const { framePath, ignoredEmailAddresses } = JSON.parse(
-    document.currentScript.innerText
-  );
   // attach to forms
   attachToEmailForms({ framePath, ignoredEmailAddresses });
+  window.__subscriptionscore_patchForm = patchSubmittingForm;
 })();

--- a/src/js/content/onload.js
+++ b/src/js/content/onload.js
@@ -146,9 +146,11 @@ function doSubmit($form) {
   if ($form._onsubmit) {
     $form.onsubmit = $form._onsubmit;
     if (typeof $form.onsubmit === 'function') {
-      let output = $form.onsubmit(e);
-      if (typeof output !== 'boolean') {
-        output = true;
+      doNativeSubmit = $form.onsubmit(e);
+      // submit doesn't need to return a bool, it just needs
+      // to not be false in order to allow submit
+      if (typeof doNativeSubmit !== 'boolean') {
+        doNativeSubmit = true;
       }
     }
   }

--- a/src/js/content/onload.js
+++ b/src/js/content/onload.js
@@ -139,15 +139,23 @@ function hasCriticalEmailAddress($form, ignoredEmailAddresses) {
 
 function doSubmit($form) {
   $form.removeEventListener('submit', $form._internalSubmit);
+  let doNativeSubmit = true;
+  // create our own submit event in case there is a eventListener
+  // and it returns false or preventDefault is called within it
+  const e = new Event('submit', { cancelable: true, bubbles: true });
   if ($form._onsubmit) {
-    const e = $form._originalEvent;
     $form.onsubmit = $form._onsubmit;
     if (typeof $form.onsubmit === 'function') {
-      return $form.onsubmit(e);
+      let output = $form.onsubmit(e);
+      if (typeof output !== 'boolean') {
+        output = true;
+      }
     }
   }
-  // fallback to default submit action
-  return $form.submit();
+  if (!e.defaultPrevented && doNativeSubmit) {
+    // default submit action
+    return $form.submit();
+  }
 }
 
 function onApproved() {

--- a/tests/blocking/delayed-form/index.html
+++ b/tests/blocking/delayed-form/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Form - Event Listener</title>
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <h2>Form with Event Listener</h2>
+    <div id="delayed-form"></div>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        setTimeout(() => {
+          document.getElementById('delayed-form').innerHTML = `<form
+      id="handlerForm"
+      name="submit-action-form"
+      method="get"
+      action="/submit.html"
+    >
+      <label>
+        <span>Email:</span>
+        <input
+          name="email"
+          required
+          type="text"
+          value="test@subscriptionscore.com"
+          autocomplete="username"
+        />
+      </label>
+      <label>
+        <span>Password:</span>
+        <input name="password" type="password" autocomplete="new-password" />
+      </label>
+      <input type="submit" value="Submit" />
+      <span id="output"></span>
+    </form>`;
+
+          window.handlerForm.addEventListener('submit', e => {
+            const formData = new FormData(window.handlerForm);
+            window.output.innerText = `Form submitted with email ${formData.get(
+              'email'
+            )}`;
+
+            return true;
+          });
+        }, 2000);
+      });
+    </script>
+  </body>
+</html>

--- a/tests/blocking/handler-and-action/index.html
+++ b/tests/blocking/handler-and-action/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Form - Submit Handler</title>
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <h2>Form with Submit Handler</h2>
+    <form id="handlerForm" name="handler-action-form" action="/submit.html">
+      <label>
+        <span>Email:</span>
+        <input
+          name="email"
+          required
+          type="text"
+          value="test@subscriptionscore.com"
+        />
+      </label>
+      <label>
+        <span>Password:</span>
+        <input name="password" type="password" />
+      </label>
+      <input type="submit" value="Submit" />
+    </form>
+    <span id="output"></span>
+    <script>
+      window.handlerForm.addEventListener('submit', e => {
+        window.output.innerText = `submitting...`;
+        return true;
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
- Fix forms not submitting properly when they have both a native handler and a submit handler that delegates to it
- Fix issue where sometimes the page could run a script before our patch script, so forms could sneak in a submit handler. Now we run the patch script before anything else in the DOM loads.
- Improvement, will now handle forms that lazy load, so long as they have a `submit` handler and not a native action. 

Fixes #18
Fixes #20
Fixes #21